### PR TITLE
Deploy error fix

### DIFF
--- a/.sf/config.json
+++ b/.sf/config.json
@@ -1,0 +1,3 @@
+{
+  "target-org": "MyDevOrg"
+}

--- a/.sf/config.json
+++ b/.sf/config.json
@@ -1,3 +1,0 @@
-{
-  "target-org": "MyDevOrg"
-}

--- a/force-app/main/default/tabs/Invoice__c.tab-meta.xml
+++ b/force-app/main/default/tabs/Invoice__c.tab-meta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom18: Form</motif>
 </CustomTab>

--- a/force-brf/main/tabs/brf_BatchApexErrorLog__c.tab-meta.xml
+++ b/force-brf/main/tabs/brf_BatchApexErrorLog__c.tab-meta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom67: Gears</motif>
 </CustomTab>


### PR DESCRIPTION
The 'mobileReady' property is removed as of Summer'19 release. So fixing the tabs metadata by removing the property.

https://help.salesforce.com/s/articleView?id=release-notes.rn_api_meta.htm&type=5&release=220